### PR TITLE
remove "use" statement for Term in the Term file

### DIFF
--- a/lib/Term.php
+++ b/lib/Term.php
@@ -6,7 +6,6 @@ use Timber\Core;
 use Timber\CoreInterface;
 
 use Timber\Post;
-use TImber\Term;
 use Timber\Helper;
 use Timber\URLHelper;
 


### PR DESCRIPTION
Simple line removal to fix bug with "use" statement

issue 984
